### PR TITLE
Use badgelib for status badge rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ checksum = "940074e50ab8a902980dec23d265697dd1e8789e66be664d183dbb24c79b8e7c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -283,7 +283,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -295,7 +295,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -307,7 +307,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -319,7 +319,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -506,6 +506,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "badgelib"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49eacfc65dde3241384baab02a4df9ffc2540ac54d971dd049b625c65113beb7"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "maud",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +536,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -778,7 +798,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -826,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -940,7 +960,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -956,7 +976,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -966,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a5efddc880ce9e2573bd867413d9056fa2bea0206af88dec21e72178b9dc74"
 dependencies = [
  "bytes",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1381,7 +1401,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1392,7 +1412,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1434,7 +1454,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1443,7 +1463,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1495,7 +1515,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1516,7 +1536,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1551,7 +1571,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1915,7 +1935,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2187,7 +2207,7 @@ dependencies = [
  "jni",
  "rand 0.10.1",
  "rustls",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -2209,7 +2229,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.1",
  "ring",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -2237,7 +2257,7 @@ dependencies = [
  "rustls",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2725,7 +2745,7 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2755,7 +2775,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -2770,7 +2790,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2789,7 +2809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3022,6 +3042,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,7 +3107,7 @@ dependencies = [
  "metrics-util",
  "quanta",
  "rustls",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3353,7 +3395,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -3383,7 +3425,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.12.28",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3411,7 +3453,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -3607,7 +3649,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3705,7 +3747,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3810,7 +3852,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3932,7 +3974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3951,6 +3993,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
 ]
 
 [[package]]
@@ -3973,7 +4027,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4059,7 +4113,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4080,7 +4134,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4299,7 +4353,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4457,7 +4511,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4477,7 +4531,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4537,7 +4591,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -4562,7 +4616,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -4756,7 +4810,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4837,9 +4891,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4869,22 +4923,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4895,14 +4949,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4986,7 +5040,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5186,7 +5240,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5205,7 +5259,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5228,7 +5282,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -5271,7 +5325,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
  "whoami",
@@ -5310,7 +5364,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "uuid",
  "whoami",
@@ -5336,7 +5390,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "url",
  "uuid",
@@ -5419,7 +5473,7 @@ dependencies = [
  "pnet_packet",
  "rand 0.10.1",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5429,6 +5483,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5452,7 +5517,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5469,7 +5534,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
 ]
 
@@ -5534,11 +5599,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5549,18 +5614,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5665,7 +5730,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5693,7 +5758,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5894,7 +5959,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5984,7 +6049,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -6099,6 +6164,7 @@ dependencies = [
  "axum",
  "axum-server",
  "backoff",
+ "badgelib",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -6158,7 +6224,7 @@ dependencies = [
  "surge-ping",
  "syntect",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-rustls",
@@ -6240,7 +6306,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "url",
  "uuid",
 ]
@@ -6384,7 +6450,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -6623,7 +6689,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6634,7 +6700,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6859,7 +6925,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6875,7 +6941,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6968,7 +7034,7 @@ dependencies = [
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -7012,7 +7078,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7033,7 +7099,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7053,7 +7119,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7075,7 +7141,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7108,7 +7174,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,9 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "compression-br", "cors", "fs", "set-header"] }
 tower-cookies = "0.11"
 
+# SVG status badges
+badgelib = "0.5.1"
+
 # Server-rendered web UI (askama templates + askama_web axum bridge)
 askama = { version = "0.16", features = ["serde_json"] }
 askama_web = { version = "0.16", features = ["axum-0.8"] }

--- a/docs/public-status.md
+++ b/docs/public-status.md
@@ -266,9 +266,10 @@ operators can embed in README files or external dashboards. Two modes:
 ```
 
 The badge reuses the cached page payload, so it tracks the `/status`
-view inside the 10-second cache window. Unknown component ids return
-`404` with the public error envelope; only `style=flat` is recognised
-(others return `400`).
+view inside the 10-second cache window. It uses `style=flat` by default;
+`style=flat-square` and `style=for-the-badge` are also available. Unknown
+component ids return `404` with the public error envelope, and unsupported
+styles return `400`.
 
 The page editor renders ready-to-copy markdown for the overall badge and
 each on-page component. The copyable URL is built from the page's public

--- a/src/api/handlers/public.rs
+++ b/src/api/handlers/public.rs
@@ -13,6 +13,7 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
+use badgelib::Style;
 use serde::Deserialize;
 use utoipa::IntoParams;
 use uuid::Uuid;
@@ -47,8 +48,7 @@ pub struct BadgeQuery {
     /// Optional public component id. When omitted, the badge reflects the
     /// overall page state.
     pub component: Option<Uuid>,
-    /// Reserved for future visual styles. Only `flat` is accepted in v1;
-    /// any other value returns 400.
+    /// Visual style: `flat` (default), `flat-square`, or `for-the-badge`.
     pub style: Option<String>,
 }
 
@@ -261,10 +261,11 @@ pub async fn public_maintenance(
     path = "/api/public/v1/badge.svg",
     tag = "public_status",
     summary = "Embeddable SVG status badge",
-    description = "Returns a shields.io-style flat SVG badge for the overall \
-                   page or a single public component. Reuses the cached page \
-                   payload, so the badge is consistent with the /status view \
-                   within the 10-second cache window. Returns 404 if the \
+    description = "Returns a shields.io-style SVG badge for the overall page \
+                   or a single public component. Supports `flat`, \
+                   `flat-square`, and `for-the-badge` styles. Reuses the cached \
+                   page payload, so the badge is consistent with the /status \
+                   view within the 10-second cache window. Returns 404 if the \
                    `component` id is unknown or its target is not public.",
     security(),
     params(BadgeQuery),
@@ -281,13 +282,13 @@ pub async fn public_badge(
     ResolvedStatusPage(page): ResolvedStatusPage,
     Query(q): Query<BadgeQuery>,
 ) -> Result<Response, PublicAppError> {
-    if let Some(style) = q.style.as_deref()
-        && style != "flat"
-    {
-        return Err(PublicAppError::BadRequest(
-            "Unsupported style. Only 'flat' is recognised.",
-        ));
-    }
+    let style = q
+        .style
+        .as_deref()
+        .map(Style::try_from)
+        .transpose()
+        .map_err(|_| PublicAppError::BadRequest("Unsupported badge style."))?
+        .unwrap_or_default();
 
     let page = state.public_source.page(page).await?;
     let page = &*page;
@@ -307,7 +308,7 @@ pub async fn public_badge(
             (page.site_name.as_str(), text, color)
         }
     };
-    let svg = render_badge(label, status_text, color);
+    let svg = render_badge(label, status_text, color, style);
 
     let mut resp = (StatusCode::OK, svg).into_response();
     resp.headers_mut()

--- a/src/public_status/badge.rs
+++ b/src/public_status/badge.rs
@@ -1,12 +1,11 @@
 //! SVG status badge rendering.
 //!
-//! Produces a shields.io-style "flat" two-segment badge that operators can
-//! embed in README files or external dashboards. Hand-rolled SVG (no third
-//! party renderer) — output is ~600 bytes and depends only on the input
-//! state, label, and status text.
+//! Produces a shields.io-style two-segment badge that operators can embed in
+//! README files or external dashboards.
+
+use badgelib::{Badge, Color, Style};
 
 use crate::domain::{OverallState, PublicComponentStatus};
-use crate::public_status::xml::xml_escape;
 
 /// Color palette aligned with the public status page UI.
 const COLOR_GREEN: &str = "#4c1";
@@ -14,19 +13,6 @@ const COLOR_YELLOW: &str = "#dfb317";
 const COLOR_ORANGE: &str = "#fe7d37";
 const COLOR_RED: &str = "#e05d44";
 const COLOR_BLUE: &str = "#007ec6";
-
-/// Approximate character width in 11px Verdana, in user-units. Verdana renders
-/// roughly 6.5px/char on average; round up to 7 so longer strings still fit
-/// inside the colored pill on common viewers.
-const CHAR_WIDTH: u32 = 7;
-/// Horizontal padding inside each segment.
-const SEGMENT_PADDING: u32 = 10;
-const BADGE_HEIGHT: u32 = 20;
-/// Hard cap on characters considered for segment sizing. Names beyond this
-/// length still render — the segment just stops growing, so an operator can't
-/// blow the SVG `width` attribute up to multi-megabytes with a pathological
-/// `site_name` or `public_name`.
-const MAX_CHARS_PER_SEGMENT: u32 = 64;
 
 /// Mapping from overall page state to (status text, color).
 pub fn overall_badge(state: OverallState) -> (&'static str, &'static str) {
@@ -50,36 +36,16 @@ pub fn component_badge(state: PublicComponentStatus) -> (&'static str, &'static 
     }
 }
 
-/// Build a flat shields.io-style SVG badge. The label segment is gray; the
-/// status segment carries the state color.
-pub fn render_badge(label: &str, status: &str, color: &str) -> String {
-    let label_w = segment_width(label);
-    let status_w = segment_width(status);
-    let total = label_w + status_w;
-    let label_mid = label_w / 2;
-    let status_mid = label_w + status_w / 2;
-
-    let label_esc = xml_escape(label);
-    let status_esc = xml_escape(status);
-
-    format!(
-        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="{h}" role="img" aria-label="{label_esc}: {status_esc}">
-<title>{label_esc}: {status_esc}</title>
-<linearGradient id="g" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
-<mask id="m"><rect width="{total}" height="{h}" rx="3" fill="#fff"/></mask>
-<g mask="url(#m)"><rect width="{label_w}" height="{h}" fill="#555"/><rect x="{label_w}" width="{status_w}" height="{h}" fill="{color}"/><rect width="{total}" height="{h}" fill="url(#g)"/></g>
-<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11"><text x="{label_mid}" y="15" fill="#010101" fill-opacity=".3">{label_esc}</text><text x="{label_mid}" y="14">{label_esc}</text><text x="{status_mid}" y="15" fill="#010101" fill-opacity=".3">{status_esc}</text><text x="{status_mid}" y="14">{status_esc}</text></g>
-</svg>"##,
-        h = BADGE_HEIGHT,
-    )
-}
-
-fn segment_width(text: &str) -> u32 {
-    // Count Unicode scalar values rather than bytes so multibyte names render
-    // with sensible spacing. Clamped so a hostile operator-supplied name can't
-    // blow the SVG width attribute up to multi-megabytes.
-    let n = (text.chars().count() as u32).min(MAX_CHARS_PER_SEGMENT);
-    n * CHAR_WIDTH + SEGMENT_PADDING * 2
+/// Build a shields.io-style SVG badge. The label segment is gray; the status
+/// segment carries the state color.
+pub fn render_badge(label: &str, status: &str, color: &str, style: Style) -> String {
+    Badge::new()
+        .label(label)
+        .label_color(Color::Hex("555".into()))
+        .value(status)
+        .value_color(Color::try_from(color).expect("static badge color is valid"))
+        .style(style)
+        .to_svg()
 }
 
 #[cfg(test)]
@@ -118,7 +84,7 @@ mod tests {
 
     #[test]
     fn render_produces_valid_xml_root() {
-        let svg = render_badge("API", "operational", COLOR_GREEN);
+        let svg = render_badge("API", "operational", COLOR_GREEN, Style::Flat);
         assert!(svg.starts_with("<svg "));
         assert!(svg.contains("xmlns=\"http://www.w3.org/2000/svg\""));
         assert!(svg.trim_end().ends_with("</svg>"));
@@ -126,34 +92,32 @@ mod tests {
 
     #[test]
     fn render_escapes_xml_special_chars() {
-        let svg = render_badge("a&b<c>", "x\"y'z", COLOR_GREEN);
+        let svg = render_badge("a&b<c>", "x\"y'z", COLOR_GREEN, Style::Flat);
         assert!(svg.contains("a&amp;b&lt;c&gt;"));
-        assert!(svg.contains("x&quot;y&apos;z"));
+        assert!(svg.contains("x&quot;y'z"));
         assert!(!svg.contains("a&b<c>"));
+        assert!(!svg.contains("x\"y'z"));
     }
 
     #[test]
     fn render_includes_accessible_title() {
-        let svg = render_badge("API", "degraded", COLOR_YELLOW);
+        let svg = render_badge("API", "degraded", COLOR_YELLOW, Style::Flat);
         assert!(svg.contains("aria-label=\"API: degraded\""));
         assert!(svg.contains("<title>API: degraded</title>"));
     }
 
     #[test]
     fn render_carries_state_color() {
-        let svg = render_badge("X", "major outage", COLOR_RED);
+        let svg = render_badge("X", "major outage", COLOR_RED, Style::Flat);
         assert!(svg.contains(COLOR_RED));
     }
 
     #[test]
-    fn segment_width_caps_pathological_input() {
-        let huge: String = "x".repeat(10_000);
-        let capped = segment_width(&huge);
-        let unbounded = 10_000 * CHAR_WIDTH + SEGMENT_PADDING * 2;
-        assert!(capped < unbounded);
-        assert_eq!(
-            capped,
-            MAX_CHARS_PER_SEGMENT * CHAR_WIDTH + SEGMENT_PADDING * 2
-        );
+    fn render_supports_every_exposed_style() {
+        for style in [Style::Flat, Style::FlatSquare, Style::ForTheBadge] {
+            let svg = render_badge("API", "operational", COLOR_GREEN, style);
+            assert!(svg.starts_with("<svg "));
+            assert!(svg.trim_end().ends_with("</svg>"));
+        }
     }
 }

--- a/tests/public_badge_test.rs
+++ b/tests/public_badge_test.rs
@@ -5,7 +5,7 @@
 //!     overall page state in the badge text.
 //!   * `?component={id}` returns the per-component status; unknown id
 //!     returns 404 with the public error envelope (no internal detail).
-//!   * `?style=` other than `flat` returns 400.
+//!   * `?style=` accepts every documented badge style and rejects others.
 //!   * Service Unavailable propagates as 503 without leaking response shape.
 
 mod common;
@@ -160,16 +160,18 @@ async fn unknown_component_returns_404_public_envelope() {
 }
 
 #[tokio::test]
-async fn explicit_flat_style_is_accepted() {
+async fn supported_styles_are_accepted() {
     let app = build_test_app_with_public_source(|_| {}, Arc::new(BadgeSource));
-    let req = Request::builder()
-        .uri("/api/public/v1/badge.svg?style=flat")
-        .body(Body::empty())
-        .unwrap();
-    let resp = app.oneshot(req).await.unwrap();
-    let (status, ct, _) = read_body(resp).await;
-    assert_eq!(status, StatusCode::OK);
-    assert!(ct.starts_with("image/svg+xml"));
+    for style in ["flat", "flat-square", "for-the-badge"] {
+        let req = Request::builder()
+            .uri(format!("/api/public/v1/badge.svg?style={style}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        let (status, ct, _) = read_body(resp).await;
+        assert_eq!(status, StatusCode::OK, "style {style}");
+        assert!(ct.starts_with("image/svg+xml"));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What & why

Hi! I like that uptimepage serves live status badges directly from its public status page data without depending on an external badge service. The current hand-written renderer works, but SVG layout and text measurement are a separate maintenance concern from status aggregation.

I work on [badges.ws](https://badges.ws) and maintain [badgelib](https://github.com/vladkens/badgelib), a Rust library for generating badges. This replaces the custom SVG construction with `badgelib`, which handles text measurement and escaping, and makes the existing `style` parameter useful with `flat-square` and `for-the-badge` alongside the default `flat` style.

The route, status labels, state mapping, cache behavior, and public error envelope stay the same. I kept uptimepage's current colors in the implementation for now, but the yellow status background in particular has little contrast with white text. The comparison below shows the existing output, `badgelib` with the preserved colors, and `badgelib` with its more readable built-in palette; if you prefer the proposed palette, I can switch this PR to it.

![Comparison of the current renderer, badgelib with the current colors, and badgelib with the proposed palette](https://github.com/user-attachments/assets/3e34d3f0-17fc-4e68-aef3-d9f951ba526d)

Closes #119

## Checklist

- [x] Every commit is signed off (DCO)
- [ ] `cargo test` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Tests cover the changed behavior
- [x] Documentation is updated where needed
- [ ] A tracking issue was opened and discussed first
- [x] The change does not introduce a breaking API change

## Notes

Focused renderer and public badge endpoint tests pass locally.
